### PR TITLE
Add support for commandbehavior.closeconnection to executereader function dbreader

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -581,6 +581,46 @@ namespace Snowflake.Data.Tests.IntegrationTests
         }
 
         [Test]
+        public void TestSimpleCommandWithCloseConnection()
+        {
+            using (IDbConnection conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString + "poolingEnabled=false";
+
+                conn.Open();
+                IDbCommand cmd = conn.CreateCommand();
+                cmd.CommandText = "select 1";
+
+                using (var reader = cmd.ExecuteReader(CommandBehavior.CloseConnection))
+                {
+                    while (reader.Read()) { }
+                }
+
+                Assert.AreEqual(ConnectionState.Closed, conn.State);
+            }
+        }
+
+        [Test]
+        public void TestSimpleCommandWithoutCloseConnection()
+        {
+            using (IDbConnection conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString + "poolingEnabled=false";
+
+                conn.Open();
+                IDbCommand cmd = conn.CreateCommand();
+                cmd.CommandText = "select 1";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read()) { }
+                }
+
+                Assert.AreEqual(ConnectionState.Open, conn.State);
+            }
+        }
+
+        [Test]
         public void TestSimpleLargeResultSet()
         {
             using (IDbConnection conn = new SnowflakeDbConnection())

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -261,7 +261,7 @@ namespace Snowflake.Data.Client
         {
             logger.Debug($"ExecuteDbDataReader");
             SFBaseResultSet resultSet = ExecuteInternal();
-            return new SnowflakeDbDataReader(this, resultSet);
+            return new SnowflakeDbDataReader(this, resultSet, behavior);
         }
 
         protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
@@ -270,7 +270,7 @@ namespace Snowflake.Data.Client
             try
             {
                 var result = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
-                return new SnowflakeDbDataReader(this, result);
+                return new SnowflakeDbDataReader(this, result, behavior);
             }
             catch (Exception ex)
             {

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -17,6 +17,7 @@ namespace Snowflake.Data.Client
         static private readonly SFLogger logger = SFLoggerFactory.GetLogger<SnowflakeDbDataReader>();
 
         private SnowflakeDbCommand dbCommand;
+        private readonly CommandBehavior cmdBehavior;
 
         private SFBaseResultSet resultSet;
 
@@ -30,9 +31,11 @@ namespace Snowflake.Data.Client
 
         private const int MaxStringLength = 16777216; // Default maximum allowed length for VARCHAR
 
-        internal SnowflakeDbDataReader(SnowflakeDbCommand command, SFBaseResultSet resultSet)
+        internal SnowflakeDbDataReader(SnowflakeDbCommand command, SFBaseResultSet resultSet, CommandBehavior cmdBehavior = CommandBehavior.Default)
         {
             this.dbCommand = command;
+            this.cmdBehavior = cmdBehavior;
+
             this.resultSet = resultSet;
             this.isClosed = false;
             this.SchemaTable = PopulateSchemaTable(resultSet);
@@ -365,6 +368,11 @@ namespace Snowflake.Data.Client
         {
             base.Close();
             resultSet.close();
+
+            //Check command behaviour and close
+            if (cmdBehavior == CommandBehavior.CloseConnection)
+                dbCommand.Connection?.Close();
+
             isClosed = true;
         }
 


### PR DESCRIPTION
* Pass through commandbehavior from dbcommand execute reader function in to data reader for usage
* Add check to commandbehavior in data reader to close connection for commandbehavior.closeconnection
* Added tests for executereader for with and without
